### PR TITLE
Include fixes to make reaper api doc parseable

### DIFF
--- a/ultraschall_api/DocsSourcefiles/reaper-apidocs.USDocML
+++ b/ultraschall_api/DocsSourcefiles/reaper-apidocs.USDocML
@@ -8657,7 +8657,7 @@
         <description prog_lang="*">
             deprecated, see GetSetProjectInfo_String with desc="PROJECT_AUTHOR"
         </description>
-        <deprecated since_when="Reaper 6.38" alternative="GetSetProjectInfo_String with desc=\"PROJECT_AUTHOR\"(available since Reaper 6.39)"/>
+        <deprecated since_when="Reaper 6.38" alternative="GetSetProjectInfo_String with desc='PROJECT_AUTHOR'(available since Reaper 6.39)"/>
         <retvals>
             string author - the (new) project's author
         </retvals>
@@ -37007,7 +37007,7 @@
         <description indent="default">
             Returns the arc tangent of the numerator divided by the denominator, allowing the denominator to be 0, and using their signs to produce a more meaningful result.
         </description>
-        <revals>
+        <retvals>
             float arc_tangent - the arc-tangent 
         </retvals>
         <parameters>
@@ -40421,7 +40421,7 @@ mespotine
                 A=0; // set A to 0
 
                 // while A is still less than 10, add 1 to A
-                while(A<10)(
+                while(A < 10)(
                   A=A+1;
                 );
                 


### PR DESCRIPTION
Hello,

Reason I'm sending this is because I'm trying to re-use the parsing method sent by X-Raym that's contained in the reaper-vscode extension. I was getting failures when trying to parse, until I found out these three things.

I'm including these three line-changes to fix parseability:
1. at lign 8660, I was getting issues parsing nested quotes. That's a simple fixe using apostrophes instead.
2. at lign 40424, leaving the angled bracket unsurrounded by spaces was causing parsers to try to interpret that section as a tag.
3. lign 37010, I believe that's a mis-matched tag.

X-Raym's method: https://forum.cockos.com/showpost.php?p=2182879&postcount=295
VSCode extension's repo: https://github.com/GavinRay97/vscode-reascript-extension/

I'd love to target your dev branch instead of master for this PR, but I'm not sure which one it is. Please let me know and I'll change the target.

Regards,

Antoine
